### PR TITLE
docs: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bad-message.yml
+++ b/.github/ISSUE_TEMPLATE/bad-message.yml
@@ -1,0 +1,31 @@
+name: Bad commit message
+description: gitmsg generated a poor message for a real diff
+labels: ['bug', 'bad-message']
+body:
+  - type: textarea
+    id: diff
+    attributes:
+      label: Staged diff
+      description: Output of `git diff --staged` (anonymise as needed)
+      render: diff
+    validations:
+      required: true
+  - type: input
+    id: produced
+    attributes:
+      label: Message gitmsg produced
+    validations:
+      required: true
+  - type: input
+    id: expected
+    attributes:
+      label: Message you would have expected
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: gitmsg version
+      placeholder: '0.0.0'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,34 @@
+name: Bug report
+description: Something broken that isn't a bad commit message
+labels: ['bug']
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: gitmsg version
+    validations:
+      required: true
+  - type: input
+    id: node
+    attributes:
+      label: Node version
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/razakadam74/gitmsg/discussions
+    about: Questions, ideas, and "show your generated messages"

--- a/.github/ISSUE_TEMPLATE/language-request.yml
+++ b/.github/ISSUE_TEMPLATE/language-request.yml
@@ -1,0 +1,24 @@
+name: Language extractor request
+description: Request support for a new language
+labels: ['enhancement', 'language']
+body:
+  - type: input
+    id: language
+    attributes:
+      label: Language
+      placeholder: 'Python, Go, Rust, ...'
+    validations:
+      required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Example diff and desired message
+      render: diff
+    validations:
+      required: true
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Are you willing to contribute the extractor?
+      options:
+        - label: "Yes, I'll open a PR"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- One sentence describing the change. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link an issue if there is one. -->
+
+## Changes
+
+<!-- Bullet list of notable changes. -->
+
+## Checklist
+
+- [ ] Tests added or updated (when code changes)
+- [ ] `npm run format:check && npm run lint && npm run typecheck && npm test && npm run build` all pass locally
+- [ ] No new runtime dependencies (or justification provided)
+- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)


### PR DESCRIPTION
Adds GitHub issue forms and a PR template.

- .github/PULL_REQUEST_TEMPLATE.md matches the CONTRIBUTING checklist
- .github/ISSUE_TEMPLATE/bad-message.yml for the project's flagship use case
- .github/ISSUE_TEMPLATE/bug-report.yml for general bugs
- .github/ISSUE_TEMPLATE/language-request.yml for new language support
- .github/ISSUE_TEMPLATE/config.yml disables blank issues, links to Discussions

Discussions feature will be enabled after merge.