### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'friday'
+      time: '18:00'
+      timezone: 'America/Los_Angeles'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+      include: 'scope'
+    groups:
+      # Group all non-major updates into a single PR per week to reduce noise.
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+    ignore:
+      # Major updates open as separate PRs so they get their own review.
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'friday'
+      time: '18:00'
+      timezone: 'America/Los_Angeles'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore(ci)'
+      include: 'scope'
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
Adds .github/dependabot.yml.

- Two ecosystems: npm and github-actions
- Weekly schedule: Friday 18:00 America/Los_Angeles
- Minor/patch updates grouped into one PR per ecosystem
- Major updates open as individual PRs
- Conventional Commit prefixes: chore(deps), chore(deps-dev), chore(ci)

Dependabot security alerts will be enabled separately after merge.