### PR TITLE
feat: add format function for conventional commit rendering

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,27 @@
+import type { CommitMessage } from './types.js';
+
+export interface FormatOptions {
+  /** Maximum subject length (header line). Default 72. */
+  maxSubjectLength?: number;
+}
+
+/** Render a CommitMessage as a Conventional Commit string. */
+export function format(msg: CommitMessage, opts: FormatOptions = {}): string {
+  const max = opts.maxSubjectLength ?? 72;
+  const scope = msg.scope ? `(${msg.scope})` : '';
+  const breakingMark = msg.breaking ? '!' : '';
+  let header = `${msg.type}${scope}${breakingMark}: ${msg.subject}`;
+
+  if (header.length > max) {
+    const overflow = header.length - max;
+    const truncatedSubject =
+      msg.subject.slice(0, msg.subject.length - overflow - 1).trimEnd() + '…';
+    header = `${msg.type}${scope}${breakingMark}: ${truncatedSubject}`;
+  }
+
+  const parts = [header];
+  if (msg.body) parts.push('', msg.body);
+  if (msg.breaking) parts.push('', `BREAKING CHANGE: ${msg.breaking}`);
+
+  return parts.join('\n');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export type * from './types.js';
+export { format, type FormatOptions } from './format.js';

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { format } from '../src/format.js';
+import type { CommitMessage } from '../src/types.js';
+
+describe('format', () => {
+  it('formats a basic commit message', () => {
+    const msg: CommitMessage = { type: 'feat', subject: 'add login' };
+    expect(format(msg)).toBe('feat: add login');
+  });
+
+  it('includes scope', () => {
+    const msg: CommitMessage = { type: 'feat', scope: 'auth', subject: 'add login' };
+    expect(format(msg)).toBe('feat(auth): add login');
+  });
+
+  it('includes body and breaking with blank-line separators', () => {
+    const msg: CommitMessage = {
+      type: 'feat',
+      scope: 'auth',
+      subject: 'drop legacy cookies',
+      body: 'Migrate to short-lived JWTs.',
+      breaking: 'clients must reauthenticate',
+    };
+    expect(format(msg)).toBe(
+      'feat(auth)!: drop legacy cookies\n\nMigrate to short-lived JWTs.\n\nBREAKING CHANGE: clients must reauthenticate',
+    );
+  });
+
+  it('marks breaking changes with !', () => {
+    const msg: CommitMessage = {
+      type: 'feat',
+      subject: 'remove old API',
+      breaking: 'old API removed',
+    };
+    expect(format(msg)).toBe('feat!: remove old API\n\nBREAKING CHANGE: old API removed');
+  });
+
+  it('truncates long subjects with an ellipsis', () => {
+    const long = 'a'.repeat(200);
+    const out = format({ type: 'feat', subject: long }, { maxSubjectLength: 30 });
+    expect(out.length).toBeLessThanOrEqual(30);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds src/format.ts with a pure
function that renders a CommitMessage as a Conventional Commit string. Handles scope, breaking-change marker (! and
footer), optional body, and subject truncation with ellipsis when the header exceeds maxSubjectLength (default 72).
Re-exported from src/index.ts. Five Vitest cases cover the basic, scoped, kitchen-sink (body + breaking + scope),
breaking-only, and truncation paths.
