### PR TITLE
feat(analyze): add detectSubject for subject-line wording

### DIFF
--- a/src/analyze/subject.ts
+++ b/src/analyze/subject.ts
@@ -1,0 +1,103 @@
+import { basename } from 'node:path';
+import type { CommitType, FileChange, SymbolDelta } from '../types.js';
+
+function baseName(p: string): string {
+  return basename(p).replace(/\.[^.]+$/, '');
+}
+
+export interface SubjectInput {
+  type: CommitType;
+  files: FileChange[];
+  symbols: SymbolDelta;
+}
+
+export function detectSubject({ type, files, symbols }: SubjectInput): string {
+  if (files.length === 0) return 'empty commit';
+
+  if (type === 'docs') {
+    if (files.length === 1) {
+      const path = files[0]!.path;
+      if (/README/i.test(path)) return 'update README';
+      if (/CHANGELOG/i.test(path)) return 'update changelog';
+      if (/CONTRIBUTING/i.test(path)) return 'update contributing guide';
+      return `update ${baseName(path)} docs`;
+    }
+    return 'update docs';
+  }
+
+  if (type === 'test') {
+    const subjects = new Set(
+      files.map((f) =>
+        baseName(f.path)
+          .replace(/\.(test|spec)$/i, '')
+          .replace(/^test[-_]/i, ''),
+      ),
+    );
+    if (subjects.size === 1) return `add tests for ${[...subjects][0]}`;
+    return files.some((f) => f.kind === 'add') ? 'add tests' : 'update tests';
+  }
+
+  if (type === 'ci') {
+    if (files.length === 1) return `update ${baseName(files[0]!.path)} workflow`;
+    return 'update CI configuration';
+  }
+
+  if (type === 'build') {
+    if (files.length === 1) return `update ${baseName(files[0]!.path)} build config`;
+    return 'update build configuration';
+  }
+
+  if (type === 'chore') {
+    const isDeps = files.every((f) =>
+      /package(-lock)?\.json|yarn\.lock|pnpm-lock\.yaml|requirements\.txt|go\.(mod|sum)|Cargo\.(toml|lock)/.test(
+        f.path,
+      ),
+    );
+    if (isDeps) return 'update dependencies';
+    return 'misc maintenance';
+  }
+
+  if (type === 'style') return 'apply formatting';
+
+  // feat / fix / refactor / perf — use symbol delta when available
+  if (symbols.added.length === 1 && symbols.removed.length === 0) {
+    return `add ${symbols.added[0]!.name}`;
+  }
+  if (symbols.removed.length === 1 && symbols.added.length === 0) {
+    return `remove ${symbols.removed[0]!.name}`;
+  }
+  if (symbols.added.length === 1 && symbols.removed.length === 1) {
+    return `rename ${symbols.removed[0]!.name} to ${symbols.added[0]!.name}`;
+  }
+  if (symbols.added.length > 1 && symbols.removed.length === 0) {
+    // First-declared symbol tends to be the headline export.
+    const head = symbols.added[0];
+    return head ? `add ${head.name} and others` : 'add new symbols';
+  }
+
+  // No clear symbol signal — fall back to file-level descriptions.
+  const renames = files.filter((f) => f.kind === 'rename');
+  if (renames.length === files.length && renames.length > 0) {
+    if (renames.length === 1 && renames[0]!.oldPath) {
+      return `rename ${baseName(renames[0]!.oldPath)} to ${baseName(renames[0]!.path)}`;
+    }
+    return 'rename files';
+  }
+
+  const adds = files.filter((f) => f.kind === 'add');
+  if (adds.length === files.length && adds.length === 1) {
+    return `add ${baseName(adds[0]!.path)}`;
+  }
+
+  const deletes = files.filter((f) => f.kind === 'delete');
+  if (deletes.length === files.length && deletes.length === 1) {
+    return `remove ${baseName(deletes[0]!.path)}`;
+  }
+
+  if (files.length === 1) {
+    const verb = type === 'fix' ? 'fix' : type === 'perf' ? 'optimize' : 'update';
+    return `${verb} ${baseName(files[0]!.path)}`;
+  }
+
+  return type === 'fix' ? 'fix bugs' : type === 'perf' ? 'optimize hot paths' : 'refactor module';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { runGit, getStagedDiff, parseDiff } from './git.js';
 export { detectType } from './analyze/type.js';
 export { detectScope } from './analyze/scope.js';
 export { extractorFor, extractors, symbolDelta } from './languages/index.js';
+export { detectSubject, type SubjectInput } from './analyze/subject.js';

--- a/tests/analyze-subject.test.ts
+++ b/tests/analyze-subject.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+import type { CodeSymbol, FileChange, SymbolKind } from '../src/types.js';
+import { detectSubject, type SubjectInput } from '../src/analyze/subject.js';
+
+const file = (overrides: Partial<FileChange> = {}): FileChange => ({
+  path: 'src/a.ts',
+  kind: 'modify',
+  addedLines: [],
+  removedLines: [],
+  ...overrides,
+});
+
+const sym = (name: string, kind: SymbolKind = 'function', exported = true): CodeSymbol => ({
+  kind,
+  name,
+  exported,
+});
+
+const subject = (overrides: Partial<SubjectInput> = {}): SubjectInput => ({
+  type: 'feat',
+  files: [file()],
+  symbols: { added: [], removed: [] },
+  ...overrides,
+});
+
+describe('detectSubject — empty', () => {
+  it('returns "empty commit" when no files', () => {
+    expect(detectSubject(subject({ files: [] }))).toBe('empty commit');
+  });
+});
+
+describe('detectSubject — docs', () => {
+  it.each([
+    ['README.md', 'update README'],
+    ['docs/README.md', 'update README'],
+    ['CHANGELOG.md', 'update changelog'],
+    ['CONTRIBUTING.md', 'update contributing guide'],
+    ['docs/architecture.md', 'update architecture docs'],
+  ])('single docs file %s → %s', (path, expected) => {
+    expect(detectSubject(subject({ type: 'docs', files: [file({ path })] }))).toBe(expected);
+  });
+
+  it('returns "update docs" for multi-file docs', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'docs',
+          files: [file({ path: 'README.md' }), file({ path: 'CHANGELOG.md' })],
+        }),
+      ),
+    ).toBe('update docs');
+  });
+});
+
+describe('detectSubject — test', () => {
+  it('names the subject under test when all files share one', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'test',
+          files: [file({ path: 'src/auth.test.ts' }), file({ path: '__tests__/auth.spec.ts' })],
+        }),
+      ),
+    ).toBe('add tests for auth');
+  });
+
+  it('strips both .test/.spec suffix and test- prefix', () => {
+    expect(
+      detectSubject(
+        subject({ type: 'test', files: [file({ path: 'test-router.ts', kind: 'add' })] }),
+      ),
+    ).toBe('add tests for router');
+  });
+
+  it('returns "add tests" for multi-subject with at least one add', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'test',
+          files: [file({ path: 'auth.test.ts', kind: 'add' }), file({ path: 'router.test.ts' })],
+        }),
+      ),
+    ).toBe('add tests');
+  });
+
+  it('returns "update tests" for multi-subject with no adds', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'test',
+          files: [file({ path: 'auth.test.ts' }), file({ path: 'router.test.ts' })],
+        }),
+      ),
+    ).toBe('update tests');
+  });
+});
+
+describe('detectSubject — ci / build', () => {
+  it('names the workflow for single CI file', () => {
+    expect(
+      detectSubject(
+        subject({ type: 'ci', files: [file({ path: '.github/workflows/release.yml' })] }),
+      ),
+    ).toBe('update release workflow');
+  });
+
+  it('generic for multi-file CI', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'ci',
+          files: [
+            file({ path: '.github/workflows/release.yml' }),
+            file({ path: '.github/workflows/test.yml' }),
+          ],
+        }),
+      ),
+    ).toBe('update CI configuration');
+  });
+
+  it('names the build config for single build file', () => {
+    expect(
+      detectSubject(subject({ type: 'build', files: [file({ path: 'tsup.config.ts' })] })),
+    ).toBe('update tsup.config build config');
+  });
+});
+
+describe('detectSubject — chore', () => {
+  it('"update dependencies" when every file is a lockfile/manifest', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'chore',
+          files: [file({ path: 'package.json' }), file({ path: 'pnpm-lock.yaml' })],
+        }),
+      ),
+    ).toBe('update dependencies');
+  });
+
+  it('"misc maintenance" when not every file is deps', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'chore',
+          files: [file({ path: 'package.json' }), file({ path: '.editorconfig' })],
+        }),
+      ),
+    ).toBe('misc maintenance');
+  });
+});
+
+describe('detectSubject — style', () => {
+  it('always returns "apply formatting"', () => {
+    expect(detectSubject(subject({ type: 'style' }))).toBe('apply formatting');
+  });
+});
+
+describe('detectSubject — symbol-driven (feat/fix/refactor/perf)', () => {
+  it.each(['feat', 'fix', 'refactor', 'perf'] as const)(
+    'single add returns "add NAME" (type=%s)',
+    (type) => {
+      expect(
+        detectSubject(
+          subject({ type, symbols: { added: [sym('rotateRefreshToken')], removed: [] } }),
+        ),
+      ).toBe('add rotateRefreshToken');
+    },
+  );
+
+  it('single remove returns "remove NAME"', () => {
+    expect(
+      detectSubject(subject({ symbols: { added: [], removed: [sym('parseLegacyToken')] } })),
+    ).toBe('remove parseLegacyToken');
+  });
+
+  it('1 add + 1 remove returns "rename X to Y" (no similarity check)', () => {
+    expect(
+      detectSubject(
+        subject({
+          symbols: { added: [sym('parseToken')], removed: [sym('parseLegacyToken')] },
+        }),
+      ),
+    ).toBe('rename parseLegacyToken to parseToken');
+  });
+
+  it('1 add + 1 remove with unrelated names is still a rename', () => {
+    expect(
+      detectSubject(
+        subject({ symbols: { added: [sym('BarService')], removed: [sym('OldFooManager')] } }),
+      ),
+    ).toBe('rename OldFooManager to BarService');
+  });
+
+  it('returns "add NAME and others" for multiple adds with zero removes', () => {
+    expect(
+      detectSubject(
+        subject({
+          symbols: {
+            added: [sym('parseToken'), sym('rotateRefreshToken'), sym('Token', 'interface')],
+            removed: [],
+          },
+        }),
+      ),
+    ).toBe('add parseToken and others');
+  });
+});
+
+describe('detectSubject — file-level fallback', () => {
+  it('returns "rename OLD to NEW" for a single rename', () => {
+    expect(
+      detectSubject(
+        subject({
+          files: [file({ kind: 'rename', oldPath: 'src/old-name.ts', path: 'src/new-name.ts' })],
+        }),
+      ),
+    ).toBe('rename old-name to new-name');
+  });
+
+  it('returns "rename files" for multi-rename', () => {
+    expect(
+      detectSubject(
+        subject({
+          files: [
+            file({ kind: 'rename', oldPath: 'a.ts', path: 'b.ts' }),
+            file({ kind: 'rename', oldPath: 'c.ts', path: 'd.ts' }),
+          ],
+        }),
+      ),
+    ).toBe('rename files');
+  });
+
+  it('returns "add NAME" for single add of a non-extractable file', () => {
+    expect(detectSubject(subject({ files: [file({ kind: 'add', path: 'styles.css' })] }))).toBe(
+      'add styles',
+    );
+  });
+
+  it('returns "remove NAME" for single delete', () => {
+    expect(
+      detectSubject(subject({ files: [file({ kind: 'delete', path: 'old-config.json' })] })),
+    ).toBe('remove old-config');
+  });
+
+  it('returns "fix NAME" for single-file fix with no symbols', () => {
+    expect(detectSubject(subject({ type: 'fix', files: [file({ path: 'src/auth.ts' })] }))).toBe(
+      'fix auth',
+    );
+  });
+
+  it('returns "optimize NAME" for single-file perf with no symbols', () => {
+    expect(detectSubject(subject({ type: 'perf', files: [file({ path: 'src/parser.ts' })] }))).toBe(
+      'optimize parser',
+    );
+  });
+
+  it('returns "refactor module" for multi-file feat with no symbols', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'feat',
+          files: [file({ path: 'src/a.ts' }), file({ path: 'src/b.ts' })],
+        }),
+      ),
+    ).toBe('refactor module');
+  });
+
+  it('returns "fix bugs" for multi-file fix with no symbols', () => {
+    expect(
+      detectSubject(
+        subject({
+          type: 'fix',
+          files: [file({ path: 'src/a.ts' }), file({ path: 'src/b.ts' })],
+        }),
+      ),
+    ).toBe('fix bugs');
+  });
+});


### PR DESCRIPTION
Ships W9 of the learn-by-rebuilding plan.

## What
- `src/analyze/subject.ts` — `detectSubject({type, files, symbols}) => string` with the full 8-rung ladder (empty / docs / test / ci / build / chore / style / symbol-delta / file-level fallback).
- `SubjectInput` interface exported for downstream orchestration (W10).
- Private `baseName` helper (one-extension strip — preserves `vite.config`, `auth.test`).
- 33 tests in `tests/analyze-subject.test.ts` covering every branch including the file-level fallback's single-file type-aware verb rung.
- Re-exported `detectSubject` + `type SubjectInput` from `src/index.ts` (NOT `baseName` — private).

## Design notes (matching reference, deliberately)
- `and others` (not `and N more`): meaningless precision rejected.
- 1+1 → rename without similarity check: calibrates to the high prior that 1+1 in a real diff is a rename, including refactor-renames with dissimilar names.
- Deps regex duplicated with W5: different question (classification vs wording); decoupling for now.
- No `>1 removed, 0 added` mirror rung: small gap, falls through to file-level; future PR.

## Gates
- `npm run format:check` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ — **115/115 passing** (33 new)
- `npm run build` ✅