### PR TITLE
chore: post-W13 cleanup (eslint ignores + cli policy tests)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,9 @@ import prettier from 'eslint-config-prettier';
 
 export default defineConfig([
   {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  {
     files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
     plugins: { js },
     extends: ['js/recommended'],

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { spawnSync, execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const cliPath = resolve(repoRoot, 'dist', 'cli.js');
+
+function runCli(args: string[]) {
+  return spawnSync('node', [cliPath, ...args], {
+    encoding: 'utf8',
+    cwd: repoRoot,
+  });
+}
+
+describe('cli (policy surface)', () => {
+  beforeAll(() => {
+    if (!existsSync(cliPath)) {
+      execSync('npm run build', { cwd: repoRoot, stdio: 'inherit' });
+    }
+  }, 60_000);
+
+  it('rejects --max below the floor with exit code 2', () => {
+    const result = runCli(['--max', '5']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('--max must be a number');
+    expect(result.stdout).toBe('');
+  });
+
+  it('rejects unknown flags with exit code 1', () => {
+    const result = runCli(['--definitely-not-a-flag']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('gitmsg:');
+    expect(result.stderr).toMatch(/unknown|not allowed|unrecognized/i);
+  });
+
+  it('--help short-circuits before any git invocation (exits 0 outside a repo)', () => {
+    // Run from the OS root, where there is no git repo above. If --help did not
+    // short-circuit, generate() would spawn `git diff --staged` and reject,
+    // producing a non-zero exit code. A clean exit 0 proves the short-circuit.
+    const root = process.platform === 'win32' ? 'C:\\' : '/';
+    const result = spawnSync('node', [cliPath, '--help'], {
+      encoding: 'utf8',
+      cwd: root,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('--commit');
+    expect(result.stderr).toBe('');
+  });
+});


### PR DESCRIPTION
Two banked carry-overs from W13/PR #28, bundled per the user's preference.

## Commits

**chore(eslint): ignore dist, node_modules, coverage**  
  Local DX fix. `npm run build && npm run lint` was flagging the tsup-stripped empty catch block in `dist/cli.js` (`hook.ts`'s Windows-no-op `try/catch`). CI did not surface this because lint runs before build there, but the local ordering would silently rot. Adding the ignores block makes order irrelevant.

**test(cli): add policy-surface tests for --max, unknown flag, --help**  
  Three spawn-based tests against the built `dist/cli.js`:
  1. `--max 5` exits 2 with stderr explanation (semantic validation layer).
  2. `--definitely-not-a-flag` exits 1 with `gitmsg:` prefix (parseArgs strict-mode layer).
  3. `--help` short-circuits cleanly from outside any git repo (proves the short-circuit ran before `generate()` would have tried `git diff --staged`).

  `beforeAll` lazily runs `npm run build` if `dist/cli.js` is missing, so CI's existing lint→typecheck→test→build order does not need to change.

## Gates

- format:check ✅
- lint ✅ (and confirmed dist/ no longer linted)
- typecheck ✅
- test ✅ 135 passed | 2 skipped (137) — 3 new
- build ✅