### PR TITLE
docs: add heuristics reference and language extractor docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,3 +16,4 @@
 - [ ] `npm run format:check && npm run lint && npm run typecheck && npm test && npm run build` all pass locally
 - [ ] No new runtime dependencies (or justification provided)
 - [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] If this PR changes a rule documented in `docs/heuristics.md` or `docs/languages/`, the doc was updated in the same PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 Thanks for considering a contribution! gitmsg is a small, focused tool, and the most valuable contributions are usually:
 
 1. **New fixtures** — real diffs that produce bad commit messages.
-2. **Heuristic improvements** — better type/scope/subject detection.
-3. **Language extractors** — symbol extraction for new languages.
+2. **Heuristic improvements** — better type/scope/subject detection. Start at [`docs/heuristics.md`](docs/heuristics.md).
+3. **Language extractors** — symbol extraction for new languages. Start at [`docs/heuristics.md` § Language extractors](docs/heuristics.md#5-language-extractors) and [`docs/languages/`](docs/languages/).
 
 ## Ground rules
 
@@ -66,6 +66,7 @@ Trailing newlines in `.expected.txt` are trimmed before comparison; don't worry 
 - [ ] `npm run format:check && npm run lint && npm run typecheck && npm test && npm run build` all pass locally
 - [ ] No new runtime dependencies (or strong justification in PR description)
 - [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) — appropriate, since this is gitmsg
+- [ ] If this PR changes a rule documented in [`docs/heuristics.md`](docs/heuristics.md) or [`docs/languages/`](docs/languages/), the doc was updated in the same PR
 
 ## Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ feat(auth): add login
 
 ## Install
 
-Once v0.1 is published:
-
 ```bash
 npm i -g @razakadam74/gitmsg
 ```
@@ -34,9 +32,7 @@ There are roughly three options for commit messages today:
 
 ## Status
 
-🚧 Early development. Pre-v0.1 — not yet on npm. APIs and behaviour will change before v1.0.
-
-The reference implementation is complete; this repository is being rebuilt step-by-step in public as a learning exercise. See [the heuristics doc](docs/heuristics.md) (coming) for how decisions are made.
+🚧 Early development. v0.1.0 is published as [`@razakadam74/gitmsg`](https://www.npmjs.com/package/@razakadam74/gitmsg). APIs and behaviour may still change before v1.0.
 
 ## Contributing
 

--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -1,0 +1,183 @@
+# Heuristics
+
+How `gitmsg` decides what to say. Every rule is testable; if you disagree with one, add a fixture under `tests/fixtures/` that demonstrates the bad output. We change rules to fit fixtures, not the other way around.
+
+For language-specific symbol extraction, see [`languages/`](./languages/).
+
+## 1. Commit type detection
+
+An 11-rung ladder. First match wins; precedence encodes specificity.
+
+| Rung | Condition                                                                   | Type                   |
+| ---- | --------------------------------------------------------------------------- | ---------------------- |
+| 1    | No files in diff                                                            | `chore`                |
+| 2    | Every file matches `TEST_PATTERN`                                           | `test`                 |
+| 3    | Every file matches `DOC_PATTERN` or `MARKDOWN_PATTERN`                      | `docs`                 |
+| 4    | Every file matches `CI_PATTERN`                                             | `ci`                   |
+| 5    | Every file matches `DEPS_PATTERN`                                           | `chore` (scope `deps`) |
+| 6    | Every file matches `BUILD_PATTERN`                                          | `build`                |
+| 7    | Every file is a rename with no content change                               | `refactor`             |
+| 8    | Every file is whitespace-only                                               | `style`                |
+| 9    | A comment-line edit on an existing file contains a fix-shaped keyword       | `fix`                  |
+| 10   | Any new source file present                                                 | `feat`                 |
+| 11   | Added lines > removed × 1.5 → `feat`; reverse → `refactor`; else `refactor` | (default)              |
+
+### Path patterns
+
+Lives in `src/analyze/type.ts`. Patterns are regex tests against the file path.
+
+| Pattern            | Matches                                                                                                                                                                                  |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TEST_PATTERN`     | `__tests__/`, `test/`, `tests/`, `spec/`, or `.test.ext` / `.spec.ext`                                                                                                                   |
+| `DOC_PATTERN`      | `docs/`, `doc/`, `README`, `CHANGELOG`, `CONTRIBUTING`, `LICENSE`, `CODE_OF_CONDUCT`, `SECURITY`                                                                                         |
+| `MARKDOWN_PATTERN` | `.md`, `.mdx`, `.rst`, `.adoc`                                                                                                                                                           |
+| `CI_PATTERN`       | `.github/workflows/`, `.github/actions/`, `.gitlab-ci.yml`, `.travis.yml`, `azure-pipelines.yml`, `Jenkinsfile`, `.circleci/`                                                            |
+| `BUILD_PATTERN`    | `tsup.config.*`, `vite.config.*`, `rollup.config.*`, `webpack.config.*`, `esbuild.*`, `Makefile`, `Dockerfile`, `.dockerignore`, `build.gradle`, `pom.xml`, `setup.py`, `pyproject.toml` |
+| `DEPS_PATTERN`     | See sidebar below                                                                                                                                                                        |
+
+### Helpers
+
+- **`every`** — wraps `Array.prototype.every` but returns `false` on an empty array. JS's vacuous-truth would otherwise let every "every-file-is-X" guard fire on empty input.
+- **`isWhitespaceOnly`** — compares whitespace-stripped added/removed lines. A rename with no content change is whitespace-only by definition.
+- **`looksLikeFix`** — inspects only comment-line additions (`//`, `#`, `/*`) on already-existing files. Adding `// fix the off-by-one` is fix-shaped signal; an `if (bug)` line isn't.
+
+> 💡 **Decision:** `every([])` returns `true` in JavaScript. Our helper returns `false` so an empty diff falls through to rung 1 instead of satisfying every guard simultaneously.
+
+> 💡 **Decision:** The `*1.5` margin on rung 11 is a confidence threshold. A diff with 101 additions and 100 removals shouldn't flap between `feat` and `refactor` — neither side has earned the verdict.
+
+### Sidebar: dependency-file detection
+
+The `DEPS_PATTERN` regex lives in `src/analyze/patterns.ts` and is **anchored** with `(^|\/)…$` so it matches actual lockfiles, not files that happen to contain a lockfile name (`pnpm-lock.yaml.bak`, `examples/package.json.template`).
+
+Covers `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `requirements.txt`, `Pipfile`, `Pipfile.lock`, `go.mod`, `go.sum`, `Cargo.toml`, `Cargo.lock`, `Gemfile`, `Gemfile.lock`, `composer.json`, `composer.lock`.
+
+> 💡 **Decision:** Constants used by ≥ 2 analyzer modules live in `patterns.ts`; everything else stays module-local. When only one consumer remains, demote back.
+
+## 2. Scope detection
+
+Two-rung algorithm. Returns `undefined` rather than guessing when no scope is obvious.
+
+1. **Strict monorepo** — if every file matches `(packages|apps|libs)/X/…` and every match has the same `X`, the scope is `X`. Mixed packages → no scope.
+2. **Common prefix** — otherwise, strip a leading `src/`, `lib/`, `app/`, or `source/` (single pass), then take the common first path segment if every file shares it.
+
+A sanitizer (`sanitizeScope`) lowercases the result, replaces non-alphanumerics with `-`, collapses runs, and trims. Output capped at 24 characters.
+
+### Noise filter
+
+First-segment values that are never valid scopes:
+
+- `tests`, `test`, `__tests__`, `spec`, `specs`
+- `docs`, `doc`
+- `.github`
+- `packages`, `apps`, `libs` (only valid when followed by an inner package name)
+
+> 💡 **Decision:** Source-prefix stripping is **single-pass**. `src/lib/foo.ts` strips to `lib/foo.ts`, not `foo.ts`. If your repo literally has `src/lib/`, `lib` is probably your scope.
+
+> 💡 **Decision:** The noise filter checks only the **first** segment. `packages/auth/tests/jwt.test.ts` produces scope `auth` — the inner `tests/` is the package's internal layout, not a top-level concern.
+
+> 💡 **Decision:** Single-segment paths like `README.md` produce no scope. The `s.length > 1` guard rejects "the scope of this commit is `README.md`".
+
+## 3. Subject wording
+
+Operates on the commit type plus the `SymbolDelta` from language extractors plus the raw file list.
+
+### Type-specific phrasing (early-exit)
+
+| Type            | Single file                                                                               | Multi-file                   |
+| --------------- | ----------------------------------------------------------------------------------------- | ---------------------------- |
+| `docs`          | `update README` / `update changelog` / `update contributing guide` / `update <name> docs` | `update docs`                |
+| `test`          | (depends on whether the file names share a subject) — see below                           | `add tests` / `update tests` |
+| `ci`            | `update <name> workflow`                                                                  | `update CI configuration`    |
+| `build`         | `update <name> build config`                                                              | `update build configuration` |
+| `chore` (deps)  | `update dependencies`                                                                     | `update dependencies`        |
+| `chore` (other) | `misc maintenance`                                                                        | `misc maintenance`           |
+| `style`         | `apply formatting`                                                                        | `apply formatting`           |
+
+For `test`: the base names are stripped of `.test`/`.spec` suffixes and `test_`/`test-` prefixes. If all paths reduce to the same name, the subject is `add tests for <name>`; otherwise it falls back to `add tests` (if any file is new) or `update tests`.
+
+### Symbol-driven phrasing (`feat` / `fix` / `refactor` / `perf`)
+
+When language extractors produced a symbol delta:
+
+| Delta                | Subject                       |
+| -------------------- | ----------------------------- |
+| 1 add, 0 removed     | `add <name>`                  |
+| 0 added, 1 removed   | `remove <name>`               |
+| 1 add, 1 removed     | `rename <removed> to <added>` |
+| ≥ 2 added, 0 removed | `add <first> and others`      |
+
+> 💡 **Decision:** Multi-add wording uses "and others", not "and N more". The exact count carries no actionable information and invites reader bikeshedding.
+
+> 💡 **Decision:** No similarity check on the 1+1 rename rung. Real-world 1-symbol-added + 1-symbol-removed diffs are renames with high prior — including refactor-renames where names share no characters (`OldFooManager` → `BarService`).
+
+> 💡 **Decision:** When multiple symbols are added, **first-declared wins** as the headline. The reader expects the source file's first export to be the most important thing in the commit.
+
+### Fallback (no symbols extractable)
+
+In order: all-rename → `rename <old> to <new>` or `rename files`; single add → `add <name>`; single delete → `remove <name>`; single-file modify → `<verb> <name>` where verb is `fix` / `optimize` / `update` per type; multi-file modify → `fix bugs` / `optimize hot paths` / `refactor module`.
+
+Empty diff returns `empty commit`.
+
+## 4. Subject formatting
+
+Lives in `src/format.ts`. Pure function — `CommitMessage → string`.
+
+- Header shape: `type(scope)!?: subject`. `scope` and `!` are omitted when absent.
+- Body and breaking-change footer rendered after a blank line each.
+- Subject capped at `maxSubjectLength` (default 72). Overflow trimmed with a trailing `…`.
+
+> 💡 **Decision:** Body generation is not yet implemented in the analyzer. The formatter supports it — output is always empty in v1.
+
+## 5. Language extractors
+
+The contributor entry point for adding new language support.
+
+### Interface contract
+
+```ts
+interface LanguageExtractor {
+  matches(path: string): boolean;
+  extract(lines: string[]): CodeSymbol[];
+}
+```
+
+Each extractor lives in `src/languages/<lang>.ts`, exports `<lang>Extractor: LanguageExtractor`, and is registered in the `extractors` array in `src/languages/index.ts`. For per-language specifics, see [`languages/`](./languages/).
+
+### The dedup-key distinction
+
+Two different keys, two different questions.
+
+| Key                           | Used in                                 | Question                            |
+| ----------------------------- | --------------------------------------- | ----------------------------------- |
+| `${kind}:${name}:${exported}` | Per-file extraction (`extract`)         | "Are these the same record?"        |
+| `${kind}:${name}`             | Cross-file cancellation (`symbolDelta`) | "Did these two records cancel out?" |
+
+The cancellation key omits `exported`. A private-to-public flip (`function foo` → `export function foo`) cancels as a modification, not an add + remove pair.
+
+> 💡 **Decision:** Two different questions justify two different keys. Identity includes attributes; cancellation is identity-only.
+
+### Adding a new language
+
+1. Create `src/languages/<lang>.ts` exporting `<lang>Extractor`.
+2. Add docs at `docs/languages/<lang>.md` covering: file extensions, the pattern ladder, blind spots, and any language-specific decisions.
+3. Register in the `extractors` array in `src/languages/index.ts`.
+4. Mirror `tests/languages-ts.test.ts` — one test per declaration form, one for dedup, one negative-path on `matches()`.
+5. Add at least one fixture pair under `tests/fixtures/` demonstrating a real diff in the language.
+
+Keep regex single-line. If your language genuinely needs multi-line parsing (Python multi-line `def` signatures, Rust trait bodies), file an issue rather than nesting state — the tree-sitter upgrade is the right vehicle.
+
+## 6. Empty-diff handling
+
+Empty staged input is a known shape, not a panic case. Handled in exactly three places:
+
+1. `parseDiff` returns `{ files: [] }` on empty input — never throws.
+2. `detectSubject` early-exits with `"empty commit"`.
+3. `analyze`'s chore-deps scope override is guarded with `files.length > 0` so empty input doesn't get a spurious `scope: 'deps'`.
+
+> 💡 **Decision:** Guards live at function entry, not at branch sites. Defense-in-depth inside a single function fragments the contract.
+
+---
+
+## Keeping this document current
+
+If your PR changes a rule documented here, **update the doc in the same PR**. Code-and-doc drift is real; bundling prevents it. The PR checklist in [`CONTRIBUTING.md`](../CONTRIBUTING.md) calls this out explicitly.

--- a/docs/languages/ts.md
+++ b/docs/languages/ts.md
@@ -1,0 +1,50 @@
+# TypeScript / JavaScript
+
+Symbol extraction for `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`.
+
+Source: [`src/languages/ts.ts`](../../src/languages/ts.ts).
+
+## Pattern ladder
+
+Eight regex patterns, ordered exported-first. First match per line wins.
+
+| #   | Pattern shape                                               | Kind        | Exported |
+| --- | ----------------------------------------------------------- | ----------- | -------- |
+| 1   | `export default function NAME` (incl. `async`)              | `function`  | yes      |
+| 2   | `export function NAME` (incl. `async`)                      | `function`  | yes      |
+| 3   | `export class NAME` (incl. `abstract`)                      | `class`     | yes      |
+| 4   | `export interface NAME`                                     | `interface` | yes      |
+| 5   | `export type NAME =`                                        | `type`      | yes      |
+| 6   | `export const NAME` / `export let NAME` / `export var NAME` | `const`     | yes      |
+| 7   | `function NAME` (incl. `async`)                             | `function`  | no       |
+| 8   | `class NAME` (incl. `abstract`)                             | `class`     | no       |
+
+> 💡 **Decision:** Pattern order is defense-in-depth. Today no two patterns overlap, but loosening any regex in the future could collide. Exported variants come before private variants; declaration keywords (`function`, `class`, `const`) are never optional in their pattern, while modifier keywords (`async`, `abstract`) are.
+
+## Dedup key
+
+Per-file extraction uses `${kind}:${name}:${exported}`. Two `export function foo` lines in one file collapse to one record. A private-to-public flip across the diff produces two distinct records (intentional — it's a meaningful change).
+
+Cross-file cancellation uses `${kind}:${name}` (drops `exported`). See the [heuristics overview](../heuristics.md#the-dedup-key-distinction) for the rationale.
+
+## v1 blind spots
+
+Documented limitations, accepted as tradeoffs against the "single-line regex, no parser" design:
+
+- **Class methods.** A method `foo()` declared inside a class is not extracted. Only top-level `function`/`class`/`interface`/`type`/`const` declarations.
+- **Arrow-function consts.** `export const foo = () => …` is captured as `kind: 'const'`, not `kind: 'function'`. The signal that it's callable is lost.
+- **Re-exports.** `export { foo } from './bar.js'` is not extracted.
+- **Multi-line signatures.** A `function foo(` that spans multiple lines (one parameter per line) is not extracted unless the name appears on the first line.
+
+These are the right places for a future tree-sitter upgrade to land. Until then, the fix for "this exact codebase trips a blind spot" is a fixture.
+
+## File extensions
+
+Match regex: `/\.(tsx?|jsx?|mjs|cjs)$/`. Covers:
+
+- `.ts`, `.tsx` — TypeScript
+- `.js`, `.jsx` — JavaScript
+- `.mjs` — ES module JavaScript
+- `.cjs` — CommonJS JavaScript
+
+`.d.ts` files match the pattern but typically contain only declarations the extractor already handles (`export type`, `export interface`, `export function`).


### PR DESCRIPTION
docs: add heuristics reference and language extractor docs
- Add docs/heuristics.md covering type, scope, subject, formatting, language-extractor framework, and empty-diff handling
 - Add docs/languages/ts.md covering the TypeScript/JavaScript extractor
 - Update README install + status to reflect v0.1.0 on npm
 - Link heuristics doc and add doc-update item to PR checklists
 
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>