### PR TITLE
feat(scope): add signal-only intersection rung (rung 4)

### DIFF
--- a/.changeset/scope-rung-4-signal-only.md
+++ b/.changeset/scope-rung-4-signal-only.md
@@ -1,0 +1,5 @@
+---
+'@razakadam74/gitmsg': patch
+---
+
+Infer scope from signal files when noise (tests, docs, changesets) outnumbers the real cluster. Adds a fourth rung to `detectScope`: after dropping noise files entirely, if two or more signal-bearing files survive and all share the same first path segment, that segment becomes the scope. Closes #54.

--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -55,11 +55,12 @@ Covers `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `requ
 
 ## 2. Scope detection
 
-Three-rung algorithm. Returns `undefined` rather than guessing when no scope is obvious.
+Four-rung algorithm. Returns `undefined` rather than guessing when no scope is obvious.
 
 1. **Strict monorepo** — if every file matches `(packages|apps|libs)/X/…` and every match has the same `X`, the scope is `X`. Mixed packages → no scope.
 2. **Common prefix** — otherwise, strip a leading `src/`, `lib/`, `app/`, or `source/` (single pass), then take the common first path segment if every file shares it.
 3. **Dominant first segment** — if rung 2 fails because one or two files break the share (typically root-level `README.md`, `CONTRIBUTING.md`, or a stray config), take the most common first segment when it covers **≥ 50% of files AND at least 2 files**, with a single clear winner. Noise-segment names (see filter below) and monorepo roots can never _win_ rung 3, but they still **count toward the denominator** — a 2-of-4 cluster where the other 2 are in `tests/` is still 2-of-4, not 2-of-2.
+4. **Signal-only intersection** — if rung 3 also fails, drop noise files (`tests/`, `docs/`, `.github/`, `.changeset/`, monorepo-root containers) and root-level files entirely; if **2 or more** signal-bearing files survive _and_ they all share the same first segment (post-`src/` strip), that segment is the scope. This catches the case where a real cluster is outvoted by the test/doc/changeset files that ship alongside it — e.g. a new language extractor PR with 2 source files, 4 test files, 2 doc files, and a changeset.
 
 A sanitizer (`sanitizeScope`) lowercases the result, replaces non-alphanumerics with `-`, collapses runs, and trims. Output capped at 24 characters.
 
@@ -69,7 +70,7 @@ First-segment values that are never valid scopes:
 
 - `tests`, `test`, `__tests__`, `spec`, `specs`
 - `docs`, `doc`
-- `.github`
+- `.github`, `.changeset`
 - `packages`, `apps`, `libs` (only valid when followed by an inner package name)
 
 > 💡 **Decision:** Source-prefix stripping is **single-pass**. `src/lib/foo.ts` strips to `lib/foo.ts`, not `foo.ts`. If your repo literally has `src/lib/`, `lib` is probably your scope.
@@ -81,6 +82,12 @@ First-segment values that are never valid scopes:
 > 💡 **Decision:** Rung 3 counts noise files in the denominator but bars them from winning. The alternative — exclude noise entirely — would let a 1-of-1 `src/auth` + 3-of-3 `tests/` diff emit `auth`, which over-claims the scope of a mostly-test change. Path-only conservatism: heuristics should depend only on what's visible at the path level, and prefer `undefined` under uncertainty.
 
 > 💡 **Decision:** Rung 3 requires a strict majority (`bestCount / total ≥ 0.5`) **and** at least two files in the winning segment. A single straggler outvoting a single feature file (1-of-2 = 50%) needs the second file to confirm the cluster is real, not coincidence.
+
+> 💡 **Decision:** Rung 4 is more permissive than rung 3 _on which files vote_ (it drops noise entirely instead of counting it) but **equally strict on what counts as agreement** — it requires all surviving signal files to share the same first segment, not just a plurality. The `≥ 2 survivors` guard preserves rung 3's conservatism by mechanism rather than by threshold: a 1-src + N-tests diff has only one signal survivor and bails. Lowering rung 3's threshold to fix the same case was rejected because it would also let low-confidence clusters claim scope on diffs where the signal really is split.
+
+> 💡 **Decision:** `.changeset` is in the noise list because every PR in this repo ships with a changeset by recipe — it must not "count" as content for scope inference. Removing it from `NOISE_SCOPES` will cause rung 4 to stop firing on most real PRs; the `'.changeset alone -> undefined'` test row in `tests/analyze-scope.test.ts` pins this assumption.
+
+> 💡 **Decision:** "Signal" vs "noise" reflects a source-first project layout. A tests-first or docs-as-product repo would reasonably disagree with these defaults; user-configurable noise lists are deferred to the `.gitmsgrc` work (Phase 7.8).
 
 ## 3. Subject wording
 

--- a/src/analyze/scope.ts
+++ b/src/analyze/scope.ts
@@ -1,6 +1,8 @@
 import type { FileChange } from '../types.js';
 
 const SOURCE_PREFIXES = ['src/', 'lib/', 'app/', 'source/'];
+// Rung 4 (signalOnlyIntersection) depends on this list — see docs/heuristics.md §2.
+// Removing an entry will cause rung 4 to start treating those files as signal.
 const NOISE_SCOPES = new Set([
   'tests',
   'test',
@@ -10,6 +12,7 @@ const NOISE_SCOPES = new Set([
   'docs',
   'doc',
   '.github',
+  '.changeset',
 ]);
 
 const MONOREPO_ROOTS = new Set(['packages', 'apps', 'libs']);
@@ -61,6 +64,25 @@ function dominantFirstSegment(files: FileChange[]): string | undefined {
   return bestSeg;
 }
 
+function signalOnlyIntersection(files: FileChange[]): string | undefined {
+  const signal = files
+    .map((f) => stripSourcePrefix(f.path).split('/')[0] ?? '')
+    .filter((seg) => {
+      if (!seg) return false;
+      if (/\.[a-z0-9]+$/i.test(seg)) return false; // root-level file like README.md
+      const lower = seg.toLowerCase();
+      return !NOISE_SCOPES.has(lower) && !MONOREPO_ROOTS.has(lower);
+    });
+
+  if (signal.length < 2) return undefined;
+
+  const first = signal[0];
+  if (!first) return undefined;
+  if (!signal.every((s) => s === first)) return undefined;
+
+  return first;
+}
+
 export function detectScope(files: FileChange[]): string | undefined {
   if (files.length === 0) return undefined;
 
@@ -103,5 +125,14 @@ export function detectScope(files: FileChange[]): string | undefined {
     const sanitized = sanitizeScope(dominant);
     if (sanitized && sanitized.length <= 24) return sanitized;
   }
+
+  // rung 4 - signal-only intersection: drop noise files entirely; if the survivors (≥2) all share
+  // the same first segment, use it. Catches the "tests + docs + changeset outvote the real cluster" case.
+  const signalOnly = signalOnlyIntersection(files);
+  if (signalOnly) {
+    const sanitized = sanitizeScope(signalOnly);
+    if (sanitized && sanitized.length <= 24) return sanitized;
+  }
+
   return undefined;
 }

--- a/tests/analyze-scope.test.ts
+++ b/tests/analyze-scope.test.ts
@@ -110,3 +110,67 @@ describe('detectScope', () => {
     expect(detectScope(files)).toBe('auth');
   });
 });
+
+describe('detectScope rung 4 — signal-only intersection', () => {
+  it.each<{ name: string; paths: string[]; expected: string | undefined }>([
+    {
+      name: 'W19 case: src/languages cluster outvoted by tests+docs+changeset',
+      paths: [
+        'src/languages/go.ts',
+        'src/languages/index.ts',
+        'tests/languages-go.test.ts',
+        'tests/languages-index.test.ts',
+        'tests/fixtures/feat-go-handler.diff',
+        'tests/fixtures/feat-go-handler.expected.txt',
+        'docs/languages/go.md',
+        'docs/heuristics.md',
+        '.changeset/add-go-language-extractor.md',
+      ],
+      expected: 'languages',
+    },
+    {
+      name: '1 src + 3 tests -> undefined (single-signal-file guard)',
+      paths: ['src/auth/login.ts', 'tests/auth.test.ts', 'tests/foo.test.ts', 'tests/bar.test.ts'],
+      expected: undefined,
+    },
+    {
+      name: '2 src/auth + 2 src/billing + 5 tests -> undefined (no agreement between signals)',
+      paths: [
+        'src/auth/login.ts',
+        'src/auth/signup.ts',
+        'src/billing/charge.ts',
+        'src/billing/refund.ts',
+        'tests/a.test.ts',
+        'tests/b.test.ts',
+        'tests/c.test.ts',
+        'tests/d.test.ts',
+        'tests/e.test.ts',
+      ],
+      expected: undefined,
+    },
+    {
+      name: 'docs-only PR -> undefined (no signal survivors)',
+      paths: ['docs/a.md', 'docs/b.md', 'docs/c.md'],
+      expected: undefined,
+    },
+    {
+      name: 'all root-level files -> undefined (no signal survivors)',
+      paths: ['README.md', 'CONTRIBUTING.md', '.prettierignore'],
+      expected: undefined,
+    },
+    {
+      name: '.changeset alone -> undefined (noise-set pin)',
+      paths: ['.changeset/foo.md', '.changeset/bar.md'],
+      expected: undefined,
+    },
+  ])('$name', ({ paths, expected }) => {
+    const files = paths.map((p) => file(p));
+    expect(detectScope(files)).toBe(expected);
+  });
+
+  it('rung 2 fires before rung 4 on a clean 2-file shared-segment diff (precedence guard)', () => {
+    // No noise files at all -> rung 2 catches it; rung 4 would have agreed but rung 2 is stricter.
+    const files = [file('src/auth/login.ts'), file('src/auth/signup.ts')];
+    expect(detectScope(files)).toBe('auth');
+  });
+});

--- a/tests/fixtures/feat-cluster-with-noise.diff
+++ b/tests/fixtures/feat-cluster-with-noise.diff
@@ -1,0 +1,53 @@
+diff --git a/src/languages/sample.ts b/src/languages/sample.ts
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/src/languages/sample.ts
+@@ -0,0 +1,8 @@
++import type { LanguageExtractor } from '../types.js';
++
++export const sampleExtractor: LanguageExtractor = {
++  matches: (p) => /\.sample$/.test(p),
++  extract: () => [],
++};
++
++export function helperForSample(): void {}
+diff --git a/src/languages/index.ts b/src/languages/index.ts
+index 2222222..3333333 100644
+--- a/src/languages/index.ts
++++ b/src/languages/index.ts
+@@ -10,6 +10,7 @@ import { sampleExtractor } from './sample.js';
+ export const extractors: LanguageExtractor[] = [
+   tsExtractor,
++  sampleExtractor,
+ ];
+diff --git a/tests/languages-sample.test.ts b/tests/languages-sample.test.ts
+new file mode 100644
+index 0000000..4444444
+--- /dev/null
++++ b/tests/languages-sample.test.ts
+@@ -0,0 +1,5 @@
++import { describe, it, expect } from 'vitest';
++
++describe('sampleExtractor', () => {
++  it('extracts nothing for now', () => expect(true).toBe(true));
++});
+diff --git a/docs/languages/sample.md b/docs/languages/sample.md
+new file mode 100644
+index 0000000..5555555
+--- /dev/null
++++ b/docs/languages/sample.md
+@@ -0,0 +1,2 @@
++# Sample extractor
++Placeholder.
+diff --git a/.changeset/add-sample-extractor.md b/.changeset/add-sample-extractor.md
+new file mode 100644
+index 0000000..6666666
+--- /dev/null
++++ b/.changeset/add-sample-extractor.md
+@@ -0,0 +1,5 @@
++---
++'@razakadam74/gitmsg': minor
++---
++
++Add sample language extractor.

--- a/tests/fixtures/feat-cluster-with-noise.expected.txt
+++ b/tests/fixtures/feat-cluster-with-noise.expected.txt
@@ -1,0 +1,1 @@
+feat(languages): add sampleExtractor and others


### PR DESCRIPTION
 When a real cluster of source changes is outvoted by the tests/docs/changeset that ship alongside it (e.g. a new language extractor: 2 src + 4 tests + 2 docs + 1 changeset), `detectScope` previously bailed to no scope.
 
 **Rung 4 — signal-only intersection:** drop noise files (`tests/`, `docs/`, `.github/`, `.changeset/`, monorepo roots) and root-level files; if ≥ 2 signal-bearing files survive and all share the same first path segment (post `src/` strip), that segment is the scope.