### PR TITLE
feat(analyze): detect breaking changes from removed exports

### DIFF
--- a/.changeset/breaking-change-detection.md
+++ b/.changeset/breaking-change-detection.md
@@ -1,0 +1,5 @@
+---
+'@razakadam74/gitmsg': minor
+---
+
+Detect breaking changes when a public export is removed or renamed. Adds the `!` mark to the header and a `BREAKING CHANGE:` footer. Closes #49 (rules 1 and 4 — removed export, renamed export). Removed CLI flag detection (rule 2) and signature-change detection (rule 3) are deferred to follow-up issues.

--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -130,6 +130,25 @@ In order: all-rename → `rename <old> to <new>` or `rename files`; single add �
 
 Empty diff returns `empty commit`.
 
+## 3.5 Breaking-change detection
+
+Lives in `src/analyze/breaking.ts`. Pure function — `SymbolDelta → string | undefined`. When defined, the orchestrator sets `message.breaking`, which makes `format.ts` append `!` to the header (`feat(api)!: …`) and emit a `BREAKING CHANGE:` footer.
+
+| Delta shape                                                              | Footer wording                              |
+| ------------------------------------------------------------------------ | ------------------------------------------- |
+| Exactly 1 exported symbol removed AND 1 exported symbol added, same kind | `rename exported <old> to <new>`            |
+| 1 exported symbol removed                                                | `remove exported <name>`                    |
+| 2–3 exported symbols removed                                             | `remove exported <a>, <b>[, <c>]`           |
+| ≥ 4 exported symbols removed                                             | `remove exported <a>, <b>, <c>, and N more` |
+
+> 💡 **Decision:** Only **exported** removals trigger this. Removing an internal helper is a normal refactor; removing a public symbol breaks every downstream consumer. The `exported` field is set by each language extractor per its own visibility rules (see §5).
+
+> 💡 **Decision:** The rename rung requires same `kind` so that `function foo` → `class Foo` is reported as `remove exported foo` rather than a misleading rename. Different kinds with the same name are still two distinct API breakages.
+
+> 💡 **Decision:** No similarity check on the rename rung — same reason as the subject heuristic. A 1-removed-export + 1-added-export diff is overwhelmingly a rename in practice, regardless of name similarity.
+
+> 💡 **Deferred:** Signature changes (different param count of an existing exported function) are not detected in v1 — that requires extending `CodeSymbol` with a `params` field across all language extractors. Removed CLI flags (regex scan on deleted lines, scoped to bin files) are similarly deferred; both are tracked as separate issues.
+
 ## 4. Subject formatting
 
 Lives in `src/format.ts`. Pure function — `CommitMessage → string`.

--- a/src/analyze/breaking.ts
+++ b/src/analyze/breaking.ts
@@ -1,0 +1,38 @@
+import type { CodeSymbol, SymbolDelta } from '../types.js';
+
+/**
+ * Detect breaking changes by inspecting the symbol delta.
+ *
+ * v1 rules (issue #49):
+ *   - Any removed *exported* symbol = breaking (consumers can no longer import it).
+ *   - When exactly 1 exported symbol is removed and 1 is added with the same kind,
+ *     describe it as a rename rather than a removal.
+ *
+ * Deferred for follow-ups:
+ *   - Signature changes (needs CodeSymbol.params)
+ *   - Removed CLI flags (regex on removed lines, scoped to bin files)
+ */
+export function detectBreaking(symbols: SymbolDelta): string | undefined {
+  const removedExports = symbols.removed.filter((s) => s.exported);
+  if (removedExports.length === 0) return undefined;
+
+  const addedExports = symbols.added.filter((s) => s.exported);
+
+  if (
+    removedExports.length === 1 &&
+    addedExports.length === 1 &&
+    removedExports[0]!.kind === addedExports[0]!.kind
+  ) {
+    return `rename exported ${removedExports[0]!.name} to ${addedExports[0]!.name}`;
+  }
+
+  return `remove exported ${formatList(removedExports)}`;
+}
+
+function formatList(syms: CodeSymbol[]): string {
+  const names = syms.map((s) => s.name);
+  if (names.length === 1) return names[0]!;
+  if (names.length <= 3) return names.join(', ');
+  const head = names.slice(0, 3).join(', ');
+  return `${head}, and ${names.length - 3} more`;
+}

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -1,5 +1,6 @@
 import { symbolDelta } from '../languages/index.js';
 import type { CommitMessage, DiffSummary } from '../types.js';
+import { detectBreaking } from './breaking.js';
 import { DEPS_PATTERN } from './patterns.js';
 import { detectScope } from './scope.js';
 import { detectSubject } from './subject.js';
@@ -11,9 +12,11 @@ export function analyze(diff: DiffSummary): CommitMessage {
   const scope = detectScope(files);
   const symbols = symbolDelta(files);
   const subject = detectSubject({ type, files, symbols });
+  const breaking = detectBreaking(symbols);
 
   const message: CommitMessage = { type, subject };
   if (scope) message.scope = scope;
+  if (breaking) message.breaking = breaking;
 
   if (type === 'chore' && files.length > 0 && files.every((f) => DEPS_PATTERN.test(f.path))) {
     message.scope = 'deps';
@@ -22,6 +25,7 @@ export function analyze(diff: DiffSummary): CommitMessage {
   return message;
 }
 
+export { detectBreaking } from './breaking.js';
 export { detectScope } from './scope.js';
 export { detectSubject } from './subject.js';
 export { detectType } from './type.js';

--- a/src/analyze/scope.ts
+++ b/src/analyze/scope.ts
@@ -106,17 +106,19 @@ export function detectScope(files: FileChange[]): string | undefined {
   const firstSeg = segments[0]?.[0];
 
   if (!firstSeg) return undefined;
-  const lower = firstSeg.toLowerCase();
-  if (NOISE_SCOPES.has(lower) || MONOREPO_ROOTS.has(lower)) return undefined;
 
   // rung 2 - all share the same first segment (and it's not a file with extension)
   const allShare =
     segments.every((s) => s.length > 1 && s[0] === firstSeg) && !/\.[a-z0-9]+$/i.test(firstSeg);
 
   if (allShare) {
-    const sanitized = sanitizeScope(firstSeg);
-    if (sanitized && sanitized.length <= 24) return sanitized;
-    return undefined;
+    const lower = firstSeg.toLowerCase();
+    // Noise / monorepo-root segments can't be a scope; fall through to rungs 3/4
+    // instead of returning undefined so they still get to try.
+    if (!NOISE_SCOPES.has(lower) && !MONOREPO_ROOTS.has(lower)) {
+      const sanitized = sanitizeScope(firstSeg);
+      if (sanitized && sanitized.length <= 24) return sanitized;
+    }
   }
 
   // rung 3 - find the most common first segment among the files (ignoring noise segments and root-level files)

--- a/tests/analyze-breaking.test.ts
+++ b/tests/analyze-breaking.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { detectBreaking } from '../src/analyze/breaking.js';
+import type { CodeSymbol, SymbolDelta } from '../src/types.js';
+
+function sym(name: string, partial: Partial<CodeSymbol> = {}): CodeSymbol {
+  return { kind: 'function', name, exported: true, ...partial };
+}
+
+function delta(added: CodeSymbol[] = [], removed: CodeSymbol[] = []): SymbolDelta {
+  return { added, removed };
+}
+
+describe('detectBreaking', () => {
+  it('returns undefined when nothing was removed', () => {
+    expect(detectBreaking(delta([sym('foo')], []))).toBeUndefined();
+  });
+
+  it('returns undefined when only non-exported symbols were removed', () => {
+    expect(detectBreaking(delta([], [sym('foo', { exported: false })]))).toBeUndefined();
+  });
+
+  it('flags a single removed exported function', () => {
+    expect(detectBreaking(delta([], [sym('rotateToken')]))).toBe('remove exported rotateToken');
+  });
+
+  it('flags a single removed exported class', () => {
+    expect(detectBreaking(delta([], [sym('AuthError', { kind: 'class' })]))).toBe(
+      'remove exported AuthError',
+    );
+  });
+
+  it('describes a 1-for-1 same-kind swap as a rename', () => {
+    expect(detectBreaking(delta([sym('rotate')], [sym('rotateToken')]))).toBe(
+      'rename exported rotateToken to rotate',
+    );
+  });
+
+  it('does not rename across kinds (function -> class stays a removal)', () => {
+    expect(detectBreaking(delta([sym('Token', { kind: 'class' })], [sym('makeToken')]))).toBe(
+      'remove exported makeToken',
+    );
+  });
+
+  it('does not rename when there are unexported additions only', () => {
+    expect(detectBreaking(delta([sym('replacement', { exported: false })], [sym('old')]))).toBe(
+      'remove exported old',
+    );
+  });
+
+  it('ignores non-exported removals when paired with exported removals', () => {
+    expect(
+      detectBreaking(delta([], [sym('keepInternal', { exported: false }), sym('publicGone')])),
+    ).toBe('remove exported publicGone');
+  });
+
+  it('lists 2 removed exports comma-separated', () => {
+    expect(detectBreaking(delta([], [sym('a'), sym('b')]))).toBe('remove exported a, b');
+  });
+
+  it('lists 3 removed exports comma-separated', () => {
+    expect(detectBreaking(delta([], [sym('a'), sym('b'), sym('c')]))).toBe(
+      'remove exported a, b, c',
+    );
+  });
+
+  it('summarizes 4+ removed exports with "and N more"', () => {
+    expect(detectBreaking(delta([], [sym('a'), sym('b'), sym('c'), sym('d'), sym('e')]))).toBe(
+      'remove exported a, b, c, and 2 more',
+    );
+  });
+
+  it('does not rename when both sides have more than 1 export', () => {
+    expect(detectBreaking(delta([sym('a'), sym('b')], [sym('c'), sym('d')]))).toBe(
+      'remove exported c, d',
+    );
+  });
+});

--- a/tests/analyze-scope.test.ts
+++ b/tests/analyze-scope.test.ts
@@ -173,4 +173,18 @@ describe('detectScope rung 4 — signal-only intersection', () => {
     const files = [file('src/auth/login.ts'), file('src/auth/signup.ts')];
     expect(detectScope(files)).toBe('auth');
   });
+
+  it('does not let a noise first file prevent rung 4 from firing (regression)', () => {
+    // Real `git diff --staged` returns files alphabetically. A `.changeset/*` entry
+    // sorts first; the previous early-bail in rung 2 made the whole function return
+    // undefined before rungs 3/4 could try. Files here mirror that ordering.
+    const files = [
+      file('.changeset/foo.md', { kind: 'add' }),
+      file('docs/heuristics.md'),
+      file('src/analyze/breaking.ts', { kind: 'add' }),
+      file('src/analyze/index.ts'),
+      file('tests/analyze-breaking.test.ts', { kind: 'add' }),
+    ];
+    expect(detectScope(files)).toBe('analyze');
+  });
 });

--- a/tests/fixtures/feat-rename-exported-breaking.diff
+++ b/tests/fixtures/feat-rename-exported-breaking.diff
@@ -1,0 +1,12 @@
+diff --git a/src/auth/jwt.ts b/src/auth/jwt.ts
+index aaaaaaa..bbbbbbb 100644
+--- a/src/auth/jwt.ts
++++ b/src/auth/jwt.ts
+@@ -1,8 +1,8 @@
+ import { sign, verify } from 'jsonwebtoken';
+
+-export function rotateRefreshToken(token: string): string {
++export function rotate(token: string): string {
+   const decoded = verify(token, process.env.JWT_SECRET!);
+   return sign(decoded, process.env.JWT_SECRET!, { expiresIn: '7d' });
+ }

--- a/tests/fixtures/feat-rename-exported-breaking.expected.txt
+++ b/tests/fixtures/feat-rename-exported-breaking.expected.txt
@@ -1,0 +1,3 @@
+refactor(auth)!: rename rotateRefreshToken to rotate
+
+BREAKING CHANGE: rename exported rotateRefreshToken to rotate


### PR DESCRIPTION
 Closes #49 (rules 1 and 4).
 
 Adds `detectBreaking(SymbolDelta)` — when any **exported** symbol is removed, attaches a `BREAKING CHANGE:` footer and marks the header with `!`.
 
 - 1 removed export, no related add → `remove exported X`
 - 1 removed + 1 added same kind → `rename exported X to Y`
 - N removed → `remove exported X, Y, Z[, and N more]`
 
 **Drive-by fix in `scope.ts`** discovered by this PR's own dogfood: rung 2 was returning `undefined` whenever the first file's first segment was noise (real `git diff --staged` sorts alphabetically, so `.changeset/*` always sorted first → rungs 3 and 4 never got to vote on real diffs). Noise check moved *after* the `allShare` computation; +1 regression test.
 
 **Deferred to follow-up issues** (per scope discussion):
 - Rule 2 — removed CLI flag detection (fragile regex on deleted lines)
 - Rule 3 — signature changes (needs `CodeSymbol.params` across all 4 extractors)
 
 Gates: 282 tests pass (+14), prettier/eslint/tsc/build green. Minor bump (new behavior in output).