### PR TITLE
refactor(languages): extract shared runPatterns helper

### DIFF
--- a/src/languages/cs.ts
+++ b/src/languages/cs.ts
@@ -1,4 +1,5 @@
 import type { CodeSymbol, LanguageExtractor } from '../types.js';
+import { runPatterns } from './runner.js';
 
 const PATTERNS: Array<{ re: RegExp; kind: CodeSymbol['kind']; callable?: boolean }> = [
   {
@@ -13,34 +14,13 @@ const PATTERNS: Array<{ re: RegExp; kind: CodeSymbol['kind']; callable?: boolean
   { re: /^\s*(?:\w+\s+)*?class\s+(\w+)/, kind: 'class' },
 ];
 
+const EXPORT_RE = /^\s*public\s+/;
+
 export const csExtractor: LanguageExtractor = {
   matches(path: string): boolean {
     return /\.csx?$/.test(path);
   },
-  extract(lines: string[]): CodeSymbol[] {
-    const symbols: CodeSymbol[] = [];
-    const seen = new Set<string>();
-
-    for (const line of lines) {
-      for (const { re, kind, callable } of PATTERNS) {
-        const m = re.exec(line);
-        if (m && m[1]) {
-          const name = m[1];
-          const exported = /^\s*public\s/.test(line);
-          const key = `${kind}:${name}:${exported}`;
-          if (!seen.has(key)) {
-            seen.add(key);
-            const sym: CodeSymbol = { kind, name, exported };
-            if (callable) {
-              const p = /\(([^)]*)\)/.exec(line);
-              if (p) sym.params = p[1] ?? '';
-            }
-            symbols.push(sym);
-          }
-          break;
-        }
-      }
-    }
-    return symbols;
+  extract(lines: string[]) {
+    return runPatterns(lines, PATTERNS, (line) => EXPORT_RE.test(line));
   },
 };

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -1,4 +1,5 @@
 import type { CodeSymbol, LanguageExtractor } from '../types.js';
+import { runPatterns } from './runner.js';
 
 const PATTERNS: Array<{ re: RegExp; kind: CodeSymbol['kind']; callable?: boolean }> = [
   { re: /^func\s+(\w+)(?:\[[^\]]*\])?\s*\(/, kind: 'function', callable: true },
@@ -8,34 +9,13 @@ const PATTERNS: Array<{ re: RegExp; kind: CodeSymbol['kind']; callable?: boolean
   { re: /^const\s+(\w+)\s/, kind: 'const' },
 ];
 
+const EXPORT_RE = /^[A-Z]/;
+
 export const goExtractor: LanguageExtractor = {
   matches(path: string): boolean {
     return /\.go$/.test(path);
   },
-  extract(lines: string[]): CodeSymbol[] {
-    const symbols: CodeSymbol[] = [];
-    const seen = new Set<string>();
-
-    for (const line of lines) {
-      for (const { re, kind, callable } of PATTERNS) {
-        const m = re.exec(line);
-        if (m && m[1]) {
-          const name = m[1];
-          const exported = /^[A-Z]/.test(name);
-          const key = `${kind}:${name}:${exported}`;
-          if (!seen.has(key)) {
-            seen.add(key);
-            const sym: CodeSymbol = { kind, name, exported };
-            if (callable) {
-              const p = /\(([^)]*)\)/.exec(line);
-              if (p) sym.params = p[1] ?? '';
-            }
-            symbols.push(sym);
-          }
-          break;
-        }
-      }
-    }
-    return symbols;
+  extract(lines: string[]) {
+    return runPatterns(lines, PATTERNS, (_line, name) => EXPORT_RE.test(name));
   },
 };

--- a/src/languages/py.ts
+++ b/src/languages/py.ts
@@ -1,4 +1,5 @@
 import type { CodeSymbol, LanguageExtractor } from '../types.js';
+import { runPatterns } from './runner.js';
 
 const PATTERNS: Array<{ re: RegExp; kind: CodeSymbol['kind']; callable?: boolean }> = [
   { re: /^async\s+def\s+(\w+)/, kind: 'function', callable: true },
@@ -11,29 +12,7 @@ export const pyExtractor: LanguageExtractor = {
   matches(path: string): boolean {
     return /\.pyi?$/.test(path);
   },
-  extract(lines: string[]): CodeSymbol[] {
-    const symbols: CodeSymbol[] = [];
-    const seen = new Set<string>();
-    for (const line of lines) {
-      for (const { re, kind, callable } of PATTERNS) {
-        const m = re.exec(line);
-        if (m && m[1]) {
-          const name = m[1];
-          const exported = !name.startsWith('_');
-          const key = `${kind}:${name}:${exported}`;
-          if (!seen.has(key)) {
-            seen.add(key);
-            const sym: CodeSymbol = { kind, name, exported };
-            if (callable) {
-              const p = /\(([^)]*)\)/.exec(line);
-              if (p) sym.params = p[1] ?? '';
-            }
-            symbols.push(sym);
-          }
-          break;
-        }
-      }
-    }
-    return symbols;
+  extract(lines: string[]) {
+    return runPatterns(lines, PATTERNS, (_line, name) => !name.startsWith('_'));
   },
 };

--- a/src/languages/runner.ts
+++ b/src/languages/runner.ts
@@ -1,0 +1,44 @@
+import type { CodeSymbol } from '../types.js';
+
+type Pattern = {
+  re: RegExp;
+  kind: CodeSymbol['kind'];
+  callable?: boolean;
+  // Per-pattern static exported override. When set, exportedFn is not consulted.
+  // Used by extractors (e.g. TS) where the export status is encoded in the pattern itself.
+  exported?: boolean;
+};
+
+type ExportedFn = (line: string, name: string, p: Pattern) => boolean;
+
+const CALLABLE_RE = /\(([^)]*)\)/;
+
+export function runPatterns(
+  lines: string[],
+  patterns: Pattern[],
+  exportedFn: ExportedFn,
+): CodeSymbol[] {
+  const symbols: CodeSymbol[] = [];
+  const seen = new Set<string>();
+  for (const line of lines) {
+    for (const p of patterns) {
+      const m = p.re.exec(line);
+      if (m && m[1]) {
+        const name = m[1];
+        const exported = p.exported ?? exportedFn(line, name, p);
+        const key = `${p.kind}:${name}:${exported}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          const sym: CodeSymbol = { kind: p.kind, name, exported };
+          if (p.callable) {
+            const args = CALLABLE_RE.exec(line);
+            if (args) sym.params = args[1] ?? '';
+          }
+          symbols.push(sym);
+        }
+        break;
+      }
+    }
+  }
+  return symbols;
+}

--- a/src/languages/ts.ts
+++ b/src/languages/ts.ts
@@ -1,4 +1,5 @@
 import type { CodeSymbol, LanguageExtractor } from '../types.js';
+import { runPatterns } from './runner.js';
 
 const PATTERNS: Array<{
   re: RegExp;
@@ -30,27 +31,7 @@ export const tsExtractor: LanguageExtractor = {
   matches(path: string): boolean {
     return /\.(tsx?|jsx?|mjs|cjs)$/.test(path);
   },
-  extract(lines: string[]): CodeSymbol[] {
-    const symbols: CodeSymbol[] = [];
-    const seen = new Set<string>();
-    for (const line of lines) {
-      for (const { re, kind, exported, callable } of PATTERNS) {
-        const m = re.exec(line);
-        if (m && m[1]) {
-          const key = `${kind}:${m[1]}:${exported}`;
-          if (!seen.has(key)) {
-            seen.add(key);
-            const sym: CodeSymbol = { kind, name: m[1], exported };
-            if (callable) {
-              const p = /\(([^)]*)\)/.exec(line);
-              if (p) sym.params = p[1] ?? '';
-            }
-            symbols.push(sym);
-          }
-          break;
-        }
-      }
-    }
-    return symbols;
+  extract(lines: string[]) {
+    return runPatterns(lines, PATTERNS, () => false);
   },
 };

--- a/tests/languages-contract.test.ts
+++ b/tests/languages-contract.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { LanguageExtractor } from '../src/types.js';
+import { csExtractor } from '../src/languages/cs.js';
+import { goExtractor } from '../src/languages/go.js';
+import { pyExtractor } from '../src/languages/py.js';
+import { tsExtractor } from '../src/languages/ts.js';
+
+const cases: Array<{
+  name: string;
+  ex: LanguageExtractor;
+  classLine: string;
+  callLine: string;
+}> = [
+  {
+    name: 'ts',
+    ex: tsExtractor,
+    classLine: 'export class Foo {}',
+    callLine: 'export function bar() {}',
+  },
+  { name: 'py', ex: pyExtractor, classLine: 'class Foo:', callLine: 'def bar():' },
+  {
+    name: 'cs',
+    ex: csExtractor,
+    classLine: 'public class Foo {}',
+    callLine: 'public delegate int Bar();',
+  },
+  { name: 'go', ex: goExtractor, classLine: 'type Foo struct {}', callLine: 'func Bar() {}' },
+];
+
+describe('Language contract', () => {
+  it.each(cases)('$name extracts a class-like kind from classLine', ({ ex, classLine }) => {
+    const [sym] = ex.extract([classLine]);
+    expect(sym).toBeDefined();
+    expect(['class', 'interface', 'type']).toContain(sym!.kind);
+  });
+
+  it.each(cases)('$name extracts a callable kind from callLine', ({ ex, callLine }) => {
+    const [sym] = ex.extract([callLine]);
+    expect(sym).toBeDefined();
+    expect(['function', 'type']).toContain(sym!.kind);
+  });
+
+  it.each(cases)('$name de-duplicates symbols', ({ ex, classLine }) => {
+    const syms = ex.extract([classLine, classLine]);
+    expect(syms).toHaveLength(1);
+  });
+
+  it.each(cases)('$name order preserves', ({ ex, classLine, callLine }) => {
+    const syms = ex.extract([classLine, callLine]);
+    expect(syms).toHaveLength(2);
+    expect(['class', 'type']).toContain(syms[0].kind);
+    expect(['function', 'type']).toContain(syms[1].kind);
+  });
+
+  it.each(cases)('$name empty input -> empty output', ({ ex }) => {
+    const syms = ex.extract([]);
+    expect(syms).toEqual([]);
+  });
+
+  it.each(cases)('$name callable with no args has params === ""', ({ ex, callLine }) => {
+    const [sym] = ex.extract([callLine]);
+    expect(sym).toBeDefined();
+    expect(sym!.params).toBe('');
+  });
+
+  it.each(cases)('$name non-callable class-like has no params', ({ ex, classLine }) => {
+    const [sym] = ex.extract([classLine]);
+    expect(sym).toBeDefined();
+    expect(sym!.params).toBeUndefined();
+  });
+});

--- a/tests/languages-cs.test.ts
+++ b/tests/languages-cs.test.ts
@@ -43,6 +43,16 @@ describe('csExtractor', () => {
         expected: { kind: 'interface', name: 'IOrderService', exported: true },
       },
       {
+        name: 'internal interface',
+        line: 'internal interface IHelper {',
+        expected: { kind: 'interface', name: 'IHelper', exported: false },
+      },
+      {
+        name: 'no-modifier interface (defaults to internal)',
+        line: 'interface IAnonymous {',
+        expected: { kind: 'interface', name: 'IAnonymous', exported: false },
+      },
+      {
         name: 'public struct',
         line: 'public struct Point {',
         expected: { kind: 'class', name: 'Point', exported: true },


### PR DESCRIPTION
4 extractors had the same loop, dedup set, params parse — only the regex patterns and the `exported` rule differed. Pulled the common shape into `runPatterns(lines, patterns, exportedFn)`.